### PR TITLE
Typecast option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,15 @@ Early do
   require :REDIS_URL
 
   default :PROVIDER, :generic
+  default :USE_TEST, ENV['RAILS_ENV'].eql?('test'), type: :bool
 end
 ```
 
 The configuration will require the presence of `DATABASE_URL` and `REDIS_URL`
 and will raise `Early::Error` if any of them is missing. It will also set a
-default value to the env `PROVIDER`.
+default value to the env `PROVIDER` and `USE_TEST` will be converted to `boolean` instead of string
+
+Typecast supported options are: `:bool` and `:integer`
 
 ### Rails
 

--- a/lib/early.rb
+++ b/lib/early.rb
@@ -7,7 +7,7 @@
 # piece of code is hit, which may happen late in the program runtime an be easy
 # to miss.
 module Early
-  VERSION = '0.3.1'
+  VERSION = '0.4.0'
 
   class Configuration # :nodoc:
     attr_reader :variables
@@ -26,8 +26,8 @@ module Early
       end
     end
 
-    def default(name, value)
-      @variables << DefaultVariable.new(name, value)
+    def default(name, value, **args)
+      @variables << DefaultVariable.new(name, value, **args)
     end
 
     def travis(path = '.travis.yml', except: %w(DATABASE_URL RAILS_ENV))
@@ -40,9 +40,23 @@ module Early
   class DefaultVariable # :nodoc:
     attr_reader :name, :value
 
-    def initialize(name, value)
+    BOOL_MAP = {
+      'true' => true,
+      'false' => false,
+      '1' => true,
+      '0' => false
+    }
+
+    def initialize(name, value, type: nil)
       @name = String(name)
-      @value = String(value)
+      @value = case type
+               when :integer
+                 value.to_i
+               when :bool
+                 BOOL_MAP[String(value)]
+               else
+                 String(value)
+               end
     end
 
     def apply

--- a/test/early_test.rb
+++ b/test/early_test.rb
@@ -50,6 +50,17 @@ class EarlyTest < Test
     assert_equal '42', config.variables[1].value
   end
 
+  test 'supports typecasting on default' do
+    config = Early::Configuration.new do
+      default :FOO, '42', type: :integer
+      default :BAR, 'true', type: :bool
+    end
+
+    assert_equal 2, config.variables.count
+    assert_equal 42, config.variables[0].value
+    assert_equal true, config.variables[1].value
+  end
+
   test 'applies a default value' do
     assert_nil ENV['FOO']
 


### PR DESCRIPTION
When usual ENV is passed it can be integer or boolean. Using early gem everything is string.
This PR adds support of `type` option in `default` configuration

```
Early do
  default :DEVISE_DENY_OLD_PASSWORDS, ENV['RAILS_ENV'].eql?('test'), type: :bool
end
```

which will result in ENV['DEVISE_DENY_OLD_PASSWORDS'] to be `true` other then `"true"` 